### PR TITLE
fix: fixing incidents where certain raids had the wrong ability

### DIFF
--- a/data/cobblemonraiddens/raid/boss/grapploct_radical.json
+++ b/data/cobblemonraiddens/raid/boss/grapploct_radical.json
@@ -6,8 +6,7 @@
       "machpunch",
       "brutalswing",
       "armthrust"
-    ],
-    "ability": "strongjaw"
+    ]
   },
   "raid_tier": "TIER_FOUR",
   "raid_type": "FIGHTING",

--- a/data/cobblemonraiddens/raid/boss/ledian_radical.json
+++ b/data/cobblemonraiddens/raid/boss/ledian_radical.json
@@ -7,7 +7,7 @@
       "victorydance",
       "closecombat"
     ],
-    "ability": "strongjaw"
+    "ability": "ironfist"
   },
   "raid_tier": "TIER_THREE",
   "raid_type": "BUG",

--- a/data/cobblemonraiddens/raid/boss/lopunny_radical.json
+++ b/data/cobblemonraiddens/raid/boss/lopunny_radical.json
@@ -6,8 +6,7 @@
       "doubleedge",
       "brickbreak",
       "jumpkick"
-    ],
-    "ability": "strongjaw"
+    ]
   },
   "raid_tier": "TIER_FOUR",
   "raid_type": "NORMAL",


### PR DESCRIPTION
* Fixed Lopunny, Ledian and Grapploct having Strong Jaw in some raids